### PR TITLE
Added tsc checks in pre commit and test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
           node-version: "20"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Run Typescript Checks
+        run: yarn tsc --noEmit
       - name: Run tests and generate report
         run: yarn test
       - name: Upload coverage to Codecov
@@ -19,5 +21,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: PKWadsy/kint
-      - name: Run Typescript Checks
-        run: yarn tsc --noEmit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: PKWadsy/kint
+      - name: Run Typescript Checks
+        run: yarn tsc --noEmit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,4 @@
 
 yarn lint-staged
 yarn test
+yarn tsc

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+yarn tsc --noEmit
 yarn lint-staged
 yarn test
-yarn tsc --noEmit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 
 yarn lint-staged
 yarn test
-yarn tsc
+yarn tsc --noEmit

--- a/src/core/models/DefineEndpointFunction.ts
+++ b/src/core/models/DefineEndpointFunction.ts
@@ -28,4 +28,4 @@ export type DefineEndpointFunction<Context, Config, DefaultConfig> = <
     DefaultConfig,
     Validators
   >
-) => KintExport<KintEndpointMeta>;
+) => KintExport<KintEndpointMeta<Context, Config>>;

--- a/src/core/models/Resource.ts
+++ b/src/core/models/Resource.ts
@@ -3,5 +3,5 @@ import { KintEndpointMeta } from "./KintEndpointMeta";
 export type Method = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
 export type Resource = {
-  [method in Method]?: KintEndpointMeta;
+  [method in Method]?: KintEndpointMeta<unknown, unknown>;
 };


### PR DESCRIPTION
I noticed that there were two type errors when I opened up the develop branch. So I fixed them and I added a tsc --noEmit check to both the pre-commit and test workflow. 

The one on the pre-commit isn't essential and could possibly cause issues for people whos workflow sometimes includes committing broken code.  So we can revert that change if you would like. But I think it is important for the tsc checks to be required before merging a PR.

I put it in the tests with coverage workflow. I'm pretty happy with it staying there. However, it could be moved to it's own workflow if you'd prefer, separate from the coverage report.