### PR TITLE
allow middleware to access global context

### DIFF
--- a/example/middleware/auth.ts
+++ b/example/middleware/auth.ts
@@ -2,8 +2,8 @@ import { buildMiddleware } from "../../src";
 
 export const authMiddleware = buildMiddleware<
   "auth",
-  { token?: string },
-  { method: "bearer" | "none" }
+  { method: "bearer" | "none" },
+  { token?: string }
 >("auth", (request, next) => {
   console.log("[BEFORE AUTH MIDDLEWARE]");
 

--- a/src/core/buildMiddleware.ts
+++ b/src/core/buildMiddleware.ts
@@ -9,12 +9,13 @@ import { Middleware } from "./models/Middleware";
  */
 export function buildMiddleware<
   Name extends string,
-  Context = void,
   Config = void,
+  Context = void,
+  GlobalContext = void,
 >(
   name: Name,
-  handler: Middleware<Name, Context, Config>["handler"],
-): Middleware<Name, Context, Config> {
+  handler: Middleware<Name, Config, Context, GlobalContext>["handler"],
+): Middleware<Name, Config, Context, GlobalContext> {
   return {
     name,
     handler,

--- a/src/core/endpoint-builder/KintEndpointBuilder.ts
+++ b/src/core/endpoint-builder/KintEndpointBuilder.ts
@@ -97,7 +97,12 @@ export class KintEndpointBuilder<
    * @returns A new KintEndpointBuilder instance with the middleware added.
    */
   addMiddleware<Name extends string, ContextExt, ConfigExt>(
-    middleware: Middleware<NotKeyOf<Name, Config>, ContextExt, ConfigExt>,
+    middleware: Middleware<
+      NotKeyOf<Name, Config>,
+      ConfigExt,
+      ContextExt,
+      GlobalContext
+    >,
   ) {
     // TODO: Clean this function to be more readable
     // Create a new handler builder which wraps the
@@ -132,6 +137,7 @@ export class KintEndpointBuilder<
           middleware.handler(
             request,
             // Next function simply extends the context object with the extension object and calls the inner handler.
+            // eslint-disable-next-line no-type-assertion/no-type-assertion
             ((extension?: ContextExt) => {
               if (extension)
                 (context as Record<Name, ContextExt>)[middleware.name] =
@@ -139,6 +145,7 @@ export class KintEndpointBuilder<
               return wrappedInnerHandler(request, context, config);
             }) as MaybeFunction<ContextExt>,
             config[middleware.name],
+            context.global,
           );
       },
     };

--- a/src/core/models/Middleware.ts
+++ b/src/core/models/Middleware.ts
@@ -7,17 +7,23 @@ export type MaybeFunction<T> = void extends T
     ? (ext?: T | undefined) => KintResponse
     : (ext: T) => KintResponse;
 
-export type MiddlewareHandler<ContextExtension, ConfigExtension> = (
+export type MiddlewareHandler<
+  ConfigExtension,
+  ContextExtension,
+  GlobalContext = unknown,
+> = (
   request: KintRequest,
   next: MaybeFunction<ContextExtension>,
   config: ConfigExtension,
+  globalContext: GlobalContext,
 ) => KintResponse;
 
 export type Middleware<
   Name extends string,
-  ContextExtension = void,
   ConfigExtension = void,
+  ContextExtension = void,
+  GlobalContext = unknown,
 > = {
-  handler: MiddlewareHandler<ContextExtension, ConfigExtension>;
+  handler: MiddlewareHandler<ConfigExtension, ContextExtension, GlobalContext>;
   name: Name;
 };

--- a/test/helpers/buildTestMiddleware.ts
+++ b/test/helpers/buildTestMiddleware.ts
@@ -9,14 +9,14 @@ export function buildTestMiddleware<Name extends string, Context, Config>(
   name: Name,
   before: (config: Config) => Context | null = () => null,
   after: (res: KintResponse) => KintResponse = (res) => res,
-): Middleware<Name, Context | null, Config> {
-  const middlewareHandler: MiddlewareHandler<Context | null, Config> = (
+): Middleware<Name, Config, Context | null> {
+  const middlewareHandler: MiddlewareHandler<Config, Context | null> = (
     request,
     next,
     config,
   ): KintResponse => {
-    const context = before(config);
-    const result = next(context);
+    const contextExt = before(config);
+    const result = next(contextExt);
     return after(result);
   };
 

--- a/test/helpers/buildTestMiddleware.ts
+++ b/test/helpers/buildTestMiddleware.ts
@@ -5,17 +5,25 @@ import {
 } from "../../src/core/models/Middleware";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-export function buildTestMiddleware<Name extends string, Context, Config>(
+export function buildTestMiddleware<
+  Name extends string,
+  Context,
+  Config,
+  GlobalContext = unknown,
+>(
   name: Name,
-  before: (config: Config) => Context | null = () => null,
+  before: (
+    config: Config,
+    globalContext: GlobalContext,
+  ) => Context | null = () => null,
   after: (res: KintResponse) => KintResponse = (res) => res,
-): Middleware<Name, Config, Context | null> {
-  const middlewareHandler: MiddlewareHandler<Config, Context | null> = (
-    request,
-    next,
-    config,
-  ): KintResponse => {
-    const contextExt = before(config);
+): Middleware<Name, Config, Context | null, GlobalContext> {
+  const middlewareHandler: MiddlewareHandler<
+    Config,
+    Context | null,
+    GlobalContext
+  > = (request, next, config, globalContext): KintResponse => {
+    const contextExt = before(config, globalContext);
     const result = next(contextExt);
     return after(result);
   };

--- a/test/integration/complete-app/promise.test.ts
+++ b/test/integration/complete-app/promise.test.ts
@@ -5,7 +5,7 @@ import { Context } from "./Context";
 import { build } from "./kint";
 
 describe("Promise", () => {
-  test("Endpoint successfully returns a repones from a promise", async () => {
+  test("Endpoint successfully returns a response from a promise", async () => {
     const routes = path.join(__dirname, "routes");
 
     const context: Context = { a: "N/A", b: 0 };

--- a/test/integration/endpoint-builder/context.test.ts
+++ b/test/integration/endpoint-builder/context.test.ts
@@ -30,4 +30,46 @@ describe("Middleware context", () => {
 
     expect(runMiddleware).toHaveBeenCalled();
   });
+
+  test("Global context is passed into the middleware and endpoint", async () => {
+    const runEndpoint = jest.fn();
+    const runMiddlewareOne = jest.fn();
+    const runMiddlewareTwo = jest.fn();
+
+    const kint = KintEndpointBuilder.new<{ a: string; b: number }>()
+      .addMiddleware(
+        buildTestMiddleware("testOne", (config, globalContext) => {
+          runMiddlewareOne();
+          expect(globalContext).toMatchObject({ a: "string", b: 10 });
+          return null;
+        }),
+      )
+      .addMiddleware(
+        buildTestMiddleware("testTwo", (config, globalContext) => {
+          runMiddlewareTwo();
+          expect(globalContext).toMatchObject({ a: "string", b: 10 });
+          return null;
+        }),
+      );
+
+    const endpoint = kint.defineEndpoint({}, (request, context) => {
+      runEndpoint();
+
+      expect(context).toHaveProperty("global");
+      expect(context.global).toMatchObject({ a: "string", b: 10 });
+
+      return {
+        body: null,
+        status: 200,
+      };
+    });
+
+    endpoint.data.handler({} as KintRequest, {
+      global: { a: "string", b: 10 },
+    });
+
+    expect(runMiddlewareOne).toHaveBeenCalled();
+    expect(runMiddlewareTwo).toHaveBeenCalled();
+    expect(runEndpoint).toHaveBeenCalled();
+  });
 });

--- a/test/integration/endpoint-builder/middleware.test.ts
+++ b/test/integration/endpoint-builder/middleware.test.ts
@@ -16,7 +16,7 @@ describe("Middleware Integration", () => {
 
     const endpoint = KintEndpointBuilder.new<object>()
       .addMiddleware(
-        buildTestMiddleware<"first", void, object>(
+        buildTestMiddleware(
           "first",
           () => {
             events.push("first before");
@@ -28,7 +28,7 @@ describe("Middleware Integration", () => {
         ),
       )
       .addMiddleware(
-        buildTestMiddleware<"second", void, object>(
+        buildTestMiddleware(
           "second",
           () => {
             events.push("second before");

--- a/test/unit/core/middleware-builder.test.ts
+++ b/test/unit/core/middleware-builder.test.ts
@@ -6,7 +6,7 @@ describe("Middleware Builder", () => {
   test("Builds a middleware object correctly", () => {
     const doThing = jest.fn(() => {});
 
-    const middleware = buildMiddleware<"test", "context", void>(
+    const middleware = buildMiddleware<"test", void, "context", void>(
       "test",
       (request, next) => {
         doThing();


### PR DESCRIPTION
Added a new input to the middleware handler function which accepts a context object. It is unknown by default, but middleware developers can require certain dependencies through the global context type.